### PR TITLE
PE-309

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -44,7 +44,7 @@ func TestRunReachMinReplicas(t *testing.T) {
 	s.Client.SetQueueAttributes(input)
 
 	time.Sleep(10 * time.Second)
-	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(minPods), scaleSpec.Spec.Replicas, "Number of replicas should be the min")
 }
 
@@ -76,7 +76,7 @@ func TestRunReachMaxReplicas(t *testing.T) {
 	s.Client.SetQueueAttributes(input)
 
 	time.Sleep(10 * time.Second)
-	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(maxPods), scaleSpec.Spec.Replicas, "Number of replicas should be the max")
 }
 
@@ -106,7 +106,7 @@ func TestRunScaleUpCoolDown(t *testing.T) {
 	s.Client.SetQueueAttributes(input)
 
 	time.Sleep(15 * time.Second)
-	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(4), scaleSpec.Spec.Replicas, "Number of replicas should be 4 if cool down for scaling up was obeyed")
 }
 
@@ -137,7 +137,7 @@ func TestRunScaleDownCoolDown(t *testing.T) {
 	s.Client.SetQueueAttributes(input)
 
 	time.Sleep(15 * time.Second)
-	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(2), scaleSpec.Spec.Replicas, "Number of replicas should be 2 if cool down for scaling down was obeyed")
 }
 

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -44,7 +44,7 @@ func NewPodAutoScaler(kubernetesDeploymentName string, kubernetesNamespace strin
 
 func (p *PodAutoScaler) ScaleUp() error {
 	scaleInterface := p.Client.Scales(p.Namespace)
-	scale, err := scaleInterface.Get("Pod", p.Deployment)
+	scale, err := scaleInterface.Get("Deployment", p.Deployment)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get scale from kube server, no scale up occurred")
 	}
@@ -58,7 +58,7 @@ func (p *PodAutoScaler) ScaleUp() error {
 
 	scale.Spec.Replicas = currentReplicas + 1
 
-	scale, err = scaleInterface.Update("Pod", scale)
+	scale, err = scaleInterface.Update("Deployment", scale)
 	if err != nil {
 		return errors.Wrap(err, "Failed to scale up")
 	}
@@ -69,7 +69,7 @@ func (p *PodAutoScaler) ScaleUp() error {
 
 func (p *PodAutoScaler) ScaleDown() error {
 	scaleInterface := p.Client.Scales(p.Namespace)
-	scale, err := scaleInterface.Get("Pod", p.Deployment)
+	scale, err := scaleInterface.Get("Deployment", p.Deployment)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get scale from kube server, no scale up occurred")
 	}
@@ -83,7 +83,7 @@ func (p *PodAutoScaler) ScaleDown() error {
 
 	scale.Spec.Replicas = currentReplicas - 1
 
-	scale, err = scaleInterface.Update("Pod", scale)
+	scale, err = scaleInterface.Update("Deployment", scale)
 	if err != nil {
 		return errors.Wrap(err, "Failed to scale down")
 	}

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -11,6 +11,7 @@ import (
 
 type KubeClient interface {
 	Deployments(namespace string) kclient.DeploymentInterface
+	Scales(namespace string) kclient.ScaleInterface
 }
 
 type PodAutoScaler struct {
@@ -27,7 +28,7 @@ func NewPodAutoScaler(kubernetesDeploymentName string, kubernetesNamespace strin
 		panic("Failed to configure incluster config")
 	}
 
-	k8sClient, err := kclient.New(config)
+	k8sClient, err := kclient.NewExtensions(config)
 	if err != nil {
 		panic("Failed to configure client")
 	}
@@ -42,47 +43,51 @@ func NewPodAutoScaler(kubernetesDeploymentName string, kubernetesNamespace strin
 }
 
 func (p *PodAutoScaler) ScaleUp() error {
-	deployment, err := p.Client.Deployments(p.Namespace).Get(p.Deployment)
+	scaleInterface := p.Client.Scales(p.Namespace)
+	scale, err := scaleInterface.Get("Pod", p.Deployment)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get deployment from kube server, no scale up occured")
+		return errors.Wrap(err, "Failed to get scale from kube server, no scale up occurred")
 	}
-
-	currentReplicas := deployment.Spec.Replicas
+	currentReplicas := scale.Spec.Replicas
 
 	if currentReplicas >= int32(p.Max) {
 		return errors.New("Max pods reached")
+	} else {
+		log.Infof("Current replicas: %d", currentReplicas)
 	}
 
-	deployment.Spec.Replicas = currentReplicas + 1
+	scale.Spec.Replicas = currentReplicas + 1
 
-	_, err = p.Client.Deployments(p.Namespace).Update(deployment)
+	scale, err = scaleInterface.Update("Pod", scale)
 	if err != nil {
 		return errors.Wrap(err, "Failed to scale up")
 	}
 
-	log.Infof("Scale up successful. Replicas: %d", deployment.Spec.Replicas)
+	log.Infof("Scale up successful. Replicas: %d", scale.Spec.Replicas)
 	return nil
 }
 
 func (p *PodAutoScaler) ScaleDown() error {
-	deployment, err := p.Client.Deployments(p.Namespace).Get(p.Deployment)
+	scaleInterface := p.Client.Scales(p.Namespace)
+	scale, err := scaleInterface.Get("Pod", p.Deployment)
 	if err != nil {
-		return errors.Wrap(err, "Failed to get deployment from kube server, no scale down occured")
+		return errors.Wrap(err, "Failed to get scale from kube server, no scale up occurred")
 	}
-
-	currentReplicas := deployment.Spec.Replicas
+	currentReplicas := scale.Spec.Replicas
 
 	if currentReplicas <= int32(p.Min) {
 		return errors.New("Min pods reached")
+	} else {
+		log.Infof("Current replicas: %d", currentReplicas)
 	}
 
-	deployment.Spec.Replicas = currentReplicas - 1
+	scale.Spec.Replicas = currentReplicas - 1
 
-	deployment, err = p.Client.Deployments(p.Namespace).Update(deployment)
+	scale, err = scaleInterface.Update("Pod", scale)
 	if err != nil {
 		return errors.Wrap(err, "Failed to scale down")
 	}
 
-	log.Infof("Scale down successful. Replicas: %d", deployment.Spec.Replicas)
+	log.Infof("Scale down successful. Replicas: %d", scale.Spec.Replicas)
 	return nil
 }

--- a/scale/scale_test.go
+++ b/scale/scale_test.go
@@ -16,18 +16,18 @@ func TestScaleUp(t *testing.T) {
 	// Scale up replicas until we reach the max (5).
 	// Scale up again and assert that we get an error back when trying to scale up replicas pass the max
 	err := p.ScaleUp()
-	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Deployment", "test")
 	assert.Nil(t, err)
 	assert.Equal(t, int32(4), scaleSpec.Spec.Replicas)
 
 	err = p.ScaleUp()
 	assert.Nil(t, err)
-	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ = p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(5), scaleSpec.Spec.Replicas)
 
 	err = p.ScaleUp()
 	assert.NotNil(t, err)
-	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ = p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(5), scaleSpec.Spec.Replicas)
 }
 
@@ -36,17 +36,17 @@ func TestScaleDown(t *testing.T) {
 
 	err := p.ScaleDown()
 	assert.Nil(t, err)
-	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(2), scaleSpec.Spec.Replicas)
 
 	err = p.ScaleDown()
 	assert.Nil(t, err)
-	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ = p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(1), scaleSpec.Spec.Replicas)
 
 	err = p.ScaleDown()
 	assert.NotNil(t, err)
-	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	scaleSpec, _ = p.Client.Scales("test").Get("Deployment", "test")
 	assert.Equal(t, int32(1), scaleSpec.Spec.Replicas)
 }
 

--- a/scale/scale_test.go
+++ b/scale/scale_test.go
@@ -16,18 +16,19 @@ func TestScaleUp(t *testing.T) {
 	// Scale up replicas until we reach the max (5).
 	// Scale up again and assert that we get an error back when trying to scale up replicas pass the max
 	err := p.ScaleUp()
-	deployment, _ := p.Client.Deployments("test").Get("test")
+	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
 	assert.Nil(t, err)
-	assert.Equal(t, int32(4), deployment.Spec.Replicas)
+	assert.Equal(t, int32(4), scaleSpec.Spec.Replicas)
+
 	err = p.ScaleUp()
 	assert.Nil(t, err)
-	deployment, _ = p.Client.Deployments("test").Get("test")
-	assert.Equal(t, int32(5), deployment.Spec.Replicas)
+	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	assert.Equal(t, int32(5), scaleSpec.Spec.Replicas)
 
 	err = p.ScaleUp()
 	assert.NotNil(t, err)
-	deployment, _ = p.Client.Deployments("test").Get("test")
-	assert.Equal(t, int32(5), deployment.Spec.Replicas)
+	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	assert.Equal(t, int32(5), scaleSpec.Spec.Replicas)
 }
 
 func TestScaleDown(t *testing.T) {
@@ -35,26 +36,32 @@ func TestScaleDown(t *testing.T) {
 
 	err := p.ScaleDown()
 	assert.Nil(t, err)
-	deployment, _ := p.Client.Deployments("test").Get("test")
-	assert.Equal(t, int32(2), deployment.Spec.Replicas)
+	scaleSpec, _ := p.Client.Scales("test").Get("Pod", "test")
+	assert.Equal(t, int32(2), scaleSpec.Spec.Replicas)
+
 	err = p.ScaleDown()
 	assert.Nil(t, err)
-	deployment, _ = p.Client.Deployments("test").Get("test")
-	assert.Equal(t, int32(1), deployment.Spec.Replicas)
+	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	assert.Equal(t, int32(1), scaleSpec.Spec.Replicas)
 
 	err = p.ScaleDown()
 	assert.NotNil(t, err)
-	deployment, _ = p.Client.Deployments("test").Get("test")
-	assert.Equal(t, int32(1), deployment.Spec.Replicas)
+	scaleSpec, _ = p.Client.Scales("test").Get("Pod", "test")
+	assert.Equal(t, int32(1), scaleSpec.Spec.Replicas)
 }
 
 type MockDeployment struct {
 	client *MockKubeClient
 }
 
+type MockScale struct {
+	client *MockKubeClient
+}
+
 type MockKubeClient struct {
 	// stores the state of Deployment as if the api server did
 	Deployment *extensions.Deployment
+	Scale      *extensions.Scale
 }
 
 func (m *MockDeployment) Get(name string) (*extensions.Deployment, error) {
@@ -96,10 +103,30 @@ func (m *MockKubeClient) Deployments(namespace string) kclient.DeploymentInterfa
 	}
 }
 
+func (m *MockScale) Get(kind string, deployment string) (*extensions.Scale, error) {
+	return m.client.Scale, nil
+}
+
+func (m *MockScale) Update(kind string, scale *extensions.Scale) (*extensions.Scale, error) {
+	m.client.Scale.Spec.Replicas = scale.Spec.Replicas
+	return m.client.Scale, nil
+}
+
+func (m *MockKubeClient) Scales(namespace string) kclient.ScaleInterface {
+	return &MockScale{
+		client: m,
+	}
+}
+
 func NewMockKubeClient() *MockKubeClient {
 	return &MockKubeClient{
 		Deployment: &extensions.Deployment{
 			Spec: extensions.DeploymentSpec{
+				Replicas: 3,
+			},
+		},
+		Scale: &extensions.Scale{
+			Spec: extensions.ScaleSpec{
 				Replicas: 3,
 			},
 		},


### PR DESCRIPTION
## Issue
The `kube-sqs-autoscaler` uses the extensions update deployment to scale the pods. This seems to be to wipe the `nodeSelector` and the `tolerations` from the deployment spec.

## Proposed solution
Using the scales extension endpoint to scale the pods instead of updating the entire deployment. Updated the tests for the same. Please note that I have kept the deployment client specific mocks, which I'll clean them up as part of different PR. I am still not 100% sure if the `Get(Kind, DeploymentName)` returns the Scales with the current number of replicas.

## Caveats
The scales endpoint was migrated into deployments as part of later kubernetes releases. This means that the current solution may not work with 1.11+ versions. @ronny  has suggested creating our own sqs autoscaler using the plain http rest client instead of kubernetes client lib with the building differnt kube scaler implementation for 1.9 and 1.11+ kubernetes versions. I am working on it but would like to park it to prepare for the upcoming Football Malaysia event.